### PR TITLE
Ergo version correction

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,16 +52,15 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ before:
     - go generate ./...
 builds:
   - main: ./cmd/cli/main.go
+    ldflags: -s -w -X main.version="{{.Version}}"
     env:
       - CGO_ENABLED=0
     goos:
@@ -26,7 +27,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  name_template: "{{ .Version }}"
 changelog:
   sort: asc
   filters:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: release
 
 lint:
 	golangci-lint run -v
@@ -13,3 +14,6 @@ ci-lint:
 
 ci-test:
 	docker-compose -f ./docker-compose.ci.yaml run ergo-ci make test
+
+release:
+	goreleaser build --rm-dist --snapshot

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -4,6 +4,8 @@ import (
 	"github.com/beatlabs/ergo/commands"
 )
 
+var version = "develop"
+
 func main() {
-	commands.Execute()
+	commands.Execute(version)
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -15,12 +15,12 @@ var (
 )
 
 // Execute entry point for commands.
-func Execute() {
+func Execute(version string) {
 	rootCommand := setUpCommand()
 	defineRootCommandProperties(rootCommand)
 	rootCommand.AddCommand(defineStatusCommand())
 	rootCommand.AddCommand(defineTagCommand())
-	rootCommand.AddCommand(defineVersionCommand())
+	rootCommand.AddCommand(defineVersionCommand(version))
 	rootCommand.AddCommand(defineDraftCommand())
 	rootCommand.AddCommand(defineDeployCommand())
 	if err := rootCommand.Execute(); err != nil {

--- a/commands/version.go
+++ b/commands/version.go
@@ -6,13 +6,13 @@ import (
 )
 
 // defineVersionCommand defines the version command.
-func defineVersionCommand() *cobra.Command {
+func defineVersionCommand(version string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "the version of ergo",
 		Long:  "the version of ergo",
 		Run: func(cmd *cobra.Command, args []string) {
-			cli.NewCLI().PrintColorizedLine("Version: ", "0.4.1", cli.WarningType)
+			cli.NewCLI().PrintColorizedLine("Version: ", version, cli.WarningType)
 		},
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -84,3 +84,14 @@ You have to use this in order to:
 - Information about the draft release body and what will change at the time of the release.
 
 [Sample config file](.ergo.yml.dist)
+
+## Release Ergo
+
+In order to release a new version of Ergo, execute the following steps:
+1. Create a new [release](https://github.com/beatlabs/ergo/releases) and publish it
+2. Execute 
+```bash 
+make release
+````
+3. Edit the created release and add the content of the `dist` folder
+4. Point the README download URL to the latest version


### PR DESCRIPTION
After updating ergo to `v0.5.0`, I noticed it still displayed `v0.4.1`.

- Adjusted `goreleaser.yml`, such that it sets the version using ldflags
- Added make command for creating a release
- Added README explanation for releasing Ergo
- Fixed deprecated linters