### PR TITLE
Allow for nonlinear interval (without testify lib)

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -27,7 +27,8 @@ func defineDeployCommand() *cobra.Command {
 	}
 
 	deployCmd.Flags().StringVar(&releaseOffset, "releaseOffset", "1m", "Duration to wait before the first release ('5m', '1h25m', '30s')")
-	deployCmd.Flags().StringVar(&releaseInterval, "releaseInterval", "25m", "Duration to wait between releases. ('5m', '1h25m', '30s')")
+	deployCmd.Flags().StringVar(&releaseInterval, "releaseInterval", "25m", "Duration to wait between releases. ('5m', '1h25m', '30s')\n"+
+		"You can do a non-linear interval by supplying more values: ('15m,10m,5m,5m,5m')")
 	deployCmd.Flags().BoolVar(&allowForcePush, "force", false, "Allow force push if deploy branch has diverged from base")
 	deployCmd.Flags().StringVar(&branchesString, "branches", "", "Comma separated list of branches")
 	deployCmd.Flags().BoolVar(&skipConfirm, "skip-confirmation", false, "Create the draft without asking for user confirmation.")

--- a/mock/cli.go
+++ b/mock/cli.go
@@ -12,10 +12,21 @@ type CLI struct {
 
 	mu                sync.Mutex
 	ConfirmationCalls int
+	PrintTableCalls   []PrintTableVal
+}
+
+// PrintTableVal represents the values send to the PrintTable method.
+type PrintTableVal struct {
+	Header []string
+	Values [][]string
 }
 
 // PrintTable is a mock implementation.
-func (c *CLI) PrintTable(header []string, values [][]string) {}
+func (c *CLI) PrintTable(header []string, values [][]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.PrintTableCalls = append(c.PrintTableCalls, PrintTableVal{Header: header, Values: values})
+}
 
 // PrintColorizedLine is a mock implementation.
 func (c *CLI) PrintColorizedLine(title, content string, level ergo.MessageLevel) {}

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,30 @@ ergo deploy \
 --branches release-pe,release-mx,release-co,release-cl,release-gr
 ```
 
+##### Deploy with custom intervals
+
+If you don't want a linear release interval, for example you want more time between the first and second deployment, you can specify multiple release intervals.
+
+```bash
+ergo deploy \
+--owner dbaltas \
+--repo ergo \
+--releaseInterval 15m,5m,5m,5m \
+--branches release-pe,release-mx,release-co,release-cl,release-gr
+```
+
+Each release will add the next interval, and starts reading the list from the beginning in case releaseInterval list is shorter than the number of branches.
+
+```bash
+Branch      Start Time
+release-pe  12:59 CEST
+release-mx  13:14 CEST
+release-co  13:19 CEST
+release-cl  13:24 CEST
+release-gr  13:29 CEST
+Deployment? [y/N]:
+```
+
 ## Github Access
 To communicate with github you will need a [personal access token](https://github.com/settings/tokens) added on the configuration file as `access-token` on github
 

--- a/release/deploy.go
+++ b/release/deploy.go
@@ -130,7 +130,7 @@ func (r *Deploy) deployToAllReleaseBranches(
 
 // calculateReleaseTime calculate from string the interval between the releases.
 func (r *Deploy) calculateReleaseTime(releaseInterval, releaseOffset string) ([]time.Duration, *time.Time, error) {
-	intervalStrings := strings.Split(releaseInterval, " ")
+	intervalStrings := strings.Split(releaseInterval, ",")
 	intervalDurations := make([]time.Duration, 0, len(intervalStrings))
 	for _, interval := range intervalStrings {
 		intervalDuration, err := time.ParseDuration(interval)

--- a/release/deploy.go
+++ b/release/deploy.go
@@ -68,17 +68,17 @@ func (r *Deploy) Do(
 	r.c.PrintLine("Deploying ", release.ReleaseURL)
 	r.c.PrintLine("Deployment start times are estimates.")
 
-	intervalDuration, releaseTimer, err := r.calculateReleaseTime(releaseIntervalInput, releaseOffsetInput)
+	intervalDurations, releaseTimer, err := r.calculateReleaseTime(releaseIntervalInput, releaseOffsetInput)
 	if err != nil {
 		return err
 	}
 
 	releaseTime := *releaseTimer
 
-	r.printReleaseTimeBoard(releaseTime, r.releaseBranches, intervalDuration)
+	r.printReleaseTimeBoard(releaseTime, r.releaseBranches, intervalDurations)
 
 	if skipConfirm {
-		return r.deployToAllReleaseBranches(ctx, intervalDuration, releaseTime, release, allowForcePush)
+		return r.deployToAllReleaseBranches(ctx, intervalDurations, releaseTime, release, allowForcePush)
 	}
 
 	confirm, err := r.c.Confirmation("Deployment", "No deployment", "")
@@ -97,17 +97,18 @@ func (r *Deploy) Do(
 	r.c.PrintLine("Deployment will start in", untilReleaseTime.String())
 	time.Sleep(untilReleaseTime)
 
-	return r.deployToAllReleaseBranches(ctx, intervalDuration, releaseTime, release, allowForcePush)
+	return r.deployToAllReleaseBranches(ctx, intervalDurations, releaseTime, release, allowForcePush)
 }
 
 func (r *Deploy) deployToAllReleaseBranches(
 	ctx context.Context,
-	intervalDuration time.Duration,
+	intervalDurations []time.Duration,
 	releaseTime time.Time,
 	release *ergo.Release,
 	allowForcePush bool,
 ) error {
 	for i, branch := range r.releaseBranches {
+		intervalDuration := intervalDurations[i%len(intervalDurations)]
 		if i != 0 {
 			time.Sleep(intervalDuration)
 			releaseTime = releaseTime.Add(intervalDuration)
@@ -128,31 +129,41 @@ func (r *Deploy) deployToAllReleaseBranches(
 }
 
 // calculateReleaseTime calculate from string the interval between the releases.
-func (r *Deploy) calculateReleaseTime(releaseInterval, releaseOffset string) (time.Duration, *time.Time, error) {
-	intervalDuration, err := time.ParseDuration(releaseInterval)
-	if err != nil {
-		return 0, nil, fmt.Errorf("error parsing interval: %w", err)
+func (r *Deploy) calculateReleaseTime(releaseInterval, releaseOffset string) ([]time.Duration, *time.Time, error) {
+	intervalStrings := strings.Split(releaseInterval, " ")
+	intervalDurations := make([]time.Duration, 0, len(intervalStrings))
+	for _, interval := range intervalStrings {
+		intervalDuration, err := time.ParseDuration(interval)
+		if err != nil {
+			return []time.Duration{}, nil, fmt.Errorf("error parsing interval: %w", err)
+		}
+		intervalDurations = append(intervalDurations, intervalDuration)
+
 	}
 	offsetDuration, err := time.ParseDuration(releaseOffset)
 	if err != nil {
-		return 0, nil, fmt.Errorf("error parsing duration: %w", err)
+		return []time.Duration{}, nil, fmt.Errorf("error parsing duration: %w", err)
+	}
+	if len(intervalDurations) == 0 {
+		return []time.Duration{}, nil, fmt.Errorf("missing required interval durations")
 	}
 	releaseTime := time.Now().Add(offsetDuration)
-	return intervalDuration, &releaseTime, nil
+	return intervalDurations, &releaseTime, nil
 }
 
 // printReleaseTimeBoard print the release time board.
-func (r *Deploy) printReleaseTimeBoard(releaseTime time.Time, releaseBranches []string, intervalDuration time.Duration) {
+func (r *Deploy) printReleaseTimeBoard(releaseTime time.Time, releaseBranches []string, intervalDurations []time.Duration) {
 	var times [][]string
 
-	for _, branch := range releaseBranches {
+	for i, branch := range releaseBranches {
+		interval := intervalDurations[i%len(intervalDurations)]
 		timesRow := []string{branch, releaseTime.Format("15:04 MST")}
-		releaseTime = releaseTime.Add(intervalDuration)
+		releaseTime = releaseTime.Add(interval)
 		times = append(times, timesRow)
 	}
 
 	headers := []string{"Branch", "Start Time"}
-	cli.NewCLI().PrintTable(headers, times)
+	r.c.PrintTable(headers, times)
 }
 
 // updateHostReleaseBody update the host release body.

--- a/release/deploy_test.go
+++ b/release/deploy_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
-
-	"github.com/beatlabs/ergo/mock"
+	"time"
 
 	"github.com/beatlabs/ergo"
 	"github.com/beatlabs/ergo/cli"
+	"github.com/beatlabs/ergo/mock"
 )
 
 func TestNewDeployShouldNotReturnNilObject(t *testing.T) {
@@ -295,6 +296,142 @@ func TestDoWithPublishDraftEnabledError(t *testing.T) {
 			).Do(ctx, "1ms", "1ms", false, false, true)
 			if err == nil {
 				t.Errorf("NewDeploy().Do(publishDraft=true) when %q should return error", testName)
+			}
+		})
+	}
+}
+
+func TestNonLinearIntervals(t *testing.T) {
+	tests := []struct {
+		name      string
+		branches  []string
+		intervals string
+	}{
+		{
+			name:      "single branch, single interval",
+			branches:  []string{"b1"},
+			intervals: "1ms",
+		},
+		{
+			name:      "multiple branches, single interval",
+			branches:  []string{"b1", "b2", "b3", "b4"},
+			intervals: "1ms",
+		},
+		{
+			name:      "multiple branches, nonlinear intervals",
+			branches:  []string{"b1", "b2", "b3", "b4"},
+			intervals: "10ms 5ms 1ms 1ms",
+		},
+		{
+			name:      "multiple branches, fewer intervals",
+			branches:  []string{"b1", "b2", "b3", "b4"},
+			intervals: "10ms 5ms",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := &mock.RepositoryClient{}
+			c := &mock.CLI{}
+
+			host.LastReleaseFn = func() (*ergo.Release, error) {
+				return &ergo.Release{TagName: "1.0.0"}, nil
+			}
+
+			err := NewDeploy(
+				c,
+				host,
+				"baseBranch",
+				"",
+				"",
+				test.branches, map[string]string{},
+			).Do(ctx, test.intervals, "1ms", false, false, false)
+
+			if err != nil {
+				t.Errorf("NewDeploy().Do() returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNonLinearIntervalHandling(t *testing.T) {
+	ts := func(t time.Time) string {
+		return t.Format("15:04 MST")
+	}
+	tests := []struct {
+		name              string
+		branches          []string
+		intervals         string
+		expectedPrintRows [][]string
+	}{
+		{
+			name:      "single branch, single interval",
+			branches:  []string{"branch1"},
+			intervals: "1m",
+			expectedPrintRows: [][]string{
+				{"branch1", ts(time.Now())},
+			},
+		},
+		{
+			name:      "multiple branches, single interval",
+			branches:  []string{"branch1", "branch2", "branch3", "branch4"},
+			intervals: "1m",
+			expectedPrintRows: [][]string{
+				{"branch1", ts(time.Now())},
+				{"branch2", ts(time.Now().Add(1 * time.Minute))},
+				{"branch3", ts(time.Now().Add(2 * time.Minute))},
+				{"branch4", ts(time.Now().Add(3 * time.Minute))},
+			},
+		},
+		{
+			name:      "multiple branches, nonlinear intervals",
+			branches:  []string{"branch1", "branch2", "branch3", "branch4"},
+			intervals: "10m 5m 1m",
+			expectedPrintRows: [][]string{
+				{"branch1", ts(time.Now())},
+				{"branch2", ts(time.Now().Add(10 * time.Minute))},
+				{"branch3", ts(time.Now().Add(15 * time.Minute))},
+				{"branch4", ts(time.Now().Add(16 * time.Minute))},
+			},
+		},
+		{
+			name:      "multiple branches, fewer intervals",
+			branches:  []string{"branch1", "branch2", "branch3", "branch4"},
+			intervals: "10m 5m",
+			expectedPrintRows: [][]string{
+				{"branch1", ts(time.Now())},
+				{"branch2", ts(time.Now().Add(10 * time.Minute))},
+				{"branch3", ts(time.Now().Add(15 * time.Minute))},
+				{"branch4", ts(time.Now().Add(25 * time.Minute))},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cliMock := &mock.CLI{}
+			deploy := &Deploy{
+				c:               cliMock,
+				releaseBranches: test.branches,
+			}
+			intervalDurations, releaseTimer, err := deploy.calculateReleaseTime(test.intervals, "1ms")
+			if err != nil {
+				t.Errorf("NewDeploy().Do() returned error: %v", err)
+			}
+
+			releaseTime := *releaseTimer
+
+			deploy.printReleaseTimeBoard(releaseTime, deploy.releaseBranches, intervalDurations)
+			if len(cliMock.PrintTableCalls) != 1 {
+				t.Errorf("expected exactly one interaction with PrintTable")
+			}
+			PrintTableCall := cliMock.PrintTableCalls[0]
+			expected := []string{"Branch", "Start Time"}
+			if !reflect.DeepEqual(expected, PrintTableCall.Header) {
+				t.Errorf("expected %v to equal %v", expected, PrintTableCall.Header)
+			}
+			if !reflect.DeepEqual(test.expectedPrintRows, PrintTableCall.Values) {
+				t.Errorf("expected %v to equal %v", test.expectedPrintRows, PrintTableCall.Values)
 			}
 		})
 	}

--- a/release/deploy_test.go
+++ b/release/deploy_test.go
@@ -320,12 +320,12 @@ func TestNonLinearIntervals(t *testing.T) {
 		{
 			name:      "multiple branches, nonlinear intervals",
 			branches:  []string{"b1", "b2", "b3", "b4"},
-			intervals: "10ms 5ms 1ms 1ms",
+			intervals: "10ms,5ms,1ms,1ms",
 		},
 		{
 			name:      "multiple branches, fewer intervals",
 			branches:  []string{"b1", "b2", "b3", "b4"},
-			intervals: "10ms 5ms",
+			intervals: "10ms,5ms",
 		},
 	}
 
@@ -386,7 +386,7 @@ func TestNonLinearIntervalHandling(t *testing.T) {
 		{
 			name:      "multiple branches, nonlinear intervals",
 			branches:  []string{"branch1", "branch2", "branch3", "branch4"},
-			intervals: "10m 5m 1m",
+			intervals: "10m,5m,1m",
 			expectedPrintRows: [][]string{
 				{"branch1", ts(time.Now())},
 				{"branch2", ts(time.Now().Add(10 * time.Minute))},
@@ -397,7 +397,7 @@ func TestNonLinearIntervalHandling(t *testing.T) {
 		{
 			name:      "multiple branches, fewer intervals",
 			branches:  []string{"branch1", "branch2", "branch3", "branch4"},
-			intervals: "10m 5m",
+			intervals: "10m,5m",
 			expectedPrintRows: [][]string{
 				{"branch1", ts(time.Now())},
 				{"branch2", ts(time.Now().Add(10 * time.Minute))},


### PR DESCRIPTION
This PR introduces the ability to not have the same release interval for each branch. 

We release using 6 branches, where the biggest risk is at the first release. If this release goes well, the following releases have less risk as the code should be the same for all branches.
With this functionality, you can have ergo wait a longer time in initial releases, and decrease this interval in later branches.

The functionality is backwards compatible, and does not change the default behaviour.

**Example**

```bash
ergo deploy \
--owner dbaltas \
--repo ergo \
--releaseInterval 15m,5m,5m,5m \
--branches release-pe,release-mx,release-co,release-cl,release-gr
```

Will create the following output:

```
Branch      Start Time
release-pe  12:59 CEST
release-mx  13:14 CEST
release-co  13:19 CEST
release-cl  13:24 CEST
release-gr  13:29 CEST
Deployment? [y/N]:
```