### PR TITLE
Fix incorrect deployment times

### DIFF
--- a/ergo.go
+++ b/ergo.go
@@ -1,6 +1,9 @@
 package ergo
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // MessageLevel defines the level of output message.
 type MessageLevel string
@@ -27,6 +30,12 @@ type CLI interface {
 	PrintLine(content ...interface{})
 	Confirmation(actionText, cancellationMessage, successMessage string) (bool, error)
 	Input() (string, error)
+}
+
+// Time describes actions around time and waiting.
+type Time interface {
+	Sleep(duration time.Duration)
+	Now() time.Time
 }
 
 // Deploy describes the deploy process.

--- a/mock/cli.go
+++ b/mock/cli.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/beatlabs/ergo"
@@ -13,6 +15,7 @@ type CLI struct {
 	mu                sync.Mutex
 	ConfirmationCalls int
 	PrintTableCalls   []PrintTableVal
+	PrintLines        []string
 }
 
 // PrintTableVal represents the values send to the PrintTable method.
@@ -32,7 +35,13 @@ func (c *CLI) PrintTable(header []string, values [][]string) {
 func (c *CLI) PrintColorizedLine(title, content string, level ergo.MessageLevel) {}
 
 // PrintLine is a mock implementation.
-func (c *CLI) PrintLine(content ...interface{}) {}
+func (c *CLI) PrintLine(content ...interface{}) {
+	words := make([]string, 0, len(content))
+	for _, c := range content {
+		words = append(words, fmt.Sprintf("%v", c))
+	}
+	c.PrintLines = append(c.PrintLines, strings.Join(words, " "))
+}
 
 // Confirmation is a mock implementation.
 func (c *CLI) Confirmation(actionText, cancellationMessage, successMessage string) (bool, error) {

--- a/mock/time.go
+++ b/mock/time.go
@@ -1,0 +1,23 @@
+package mock
+
+import "time"
+
+// Time is a mock implementation.
+type Time struct {
+	CurrentTime time.Time
+}
+
+// NewMockedTime creates a new mocked time implementation.
+func NewMockedTime(initialTime time.Time) *Time {
+	return &Time{CurrentTime: initialTime}
+}
+
+// Sleep mocks the sleep action, adding the duration to the time.
+func (t Time) Sleep(duration time.Duration) {
+	t.CurrentTime = t.CurrentTime.Add(duration)
+}
+
+// Now returns the mocked time.
+func (t Time) Now() time.Time {
+	return t.CurrentTime
+}

--- a/mock/time.go
+++ b/mock/time.go
@@ -13,11 +13,11 @@ func NewMockedTime(initialTime time.Time) *Time {
 }
 
 // Sleep mocks the sleep action, adding the duration to the time.
-func (t Time) Sleep(duration time.Duration) {
+func (t *Time) Sleep(duration time.Duration) {
 	t.CurrentTime = t.CurrentTime.Add(duration)
 }
 
 // Now returns the mocked time.
-func (t Time) Now() time.Time {
+func (t *Time) Now() time.Time {
 	return t.CurrentTime
 }

--- a/release/deploy.go
+++ b/release/deploy.go
@@ -110,10 +110,6 @@ func (r *Deploy) deployToAllReleaseBranches(
 	allowForcePush bool,
 ) error {
 	for i, branch := range r.releaseBranches {
-		intervalDuration := intervalDurations[i%len(intervalDurations)]
-		if i != 0 {
-			r.time.Sleep(intervalDuration)
-		}
 		r.c.PrintLine("Deploying", r.time.Now().Format("15:04:05"), branch)
 
 		if errRelease := r.host.UpdateBranchFromTag(ctx, release.TagName, branch, allowForcePush); errRelease != nil {
@@ -124,6 +120,12 @@ func (r *Deploy) deployToAllReleaseBranches(
 		err := r.updateHostReleaseBody(ctx, r.releaseBodyBranches, branch, r.releaseBodyFind, r.releaseBodyReplace)
 		if err != nil {
 			return err
+		}
+
+		// Don't sleep after the last deployment
+		if i < (len(r.releaseBranches) - 1) {
+			intervalDuration := intervalDurations[i%len(intervalDurations)]
+			r.time.Sleep(intervalDuration)
 		}
 	}
 	return nil

--- a/release/deploy.go
+++ b/release/deploy.go
@@ -78,7 +78,7 @@ func (r *Deploy) Do(
 	r.printReleaseTimeBoard(releaseTime, r.releaseBranches, intervalDurations)
 
 	if skipConfirm {
-		return r.deployToAllReleaseBranches(ctx, intervalDurations, releaseTime, release, allowForcePush)
+		return r.deployToAllReleaseBranches(ctx, intervalDurations, release, allowForcePush)
 	}
 
 	confirm, err := r.c.Confirmation("Deployment", "No deployment", "")
@@ -97,13 +97,12 @@ func (r *Deploy) Do(
 	r.c.PrintLine("Deployment will start in", untilReleaseTime.String())
 	time.Sleep(untilReleaseTime)
 
-	return r.deployToAllReleaseBranches(ctx, intervalDurations, releaseTime, release, allowForcePush)
+	return r.deployToAllReleaseBranches(ctx, intervalDurations, release, allowForcePush)
 }
 
 func (r *Deploy) deployToAllReleaseBranches(
 	ctx context.Context,
 	intervalDurations []time.Duration,
-	releaseTime time.Time,
 	release *ergo.Release,
 	allowForcePush bool,
 ) error {
@@ -111,7 +110,6 @@ func (r *Deploy) deployToAllReleaseBranches(
 		intervalDuration := intervalDurations[i%len(intervalDurations)]
 		if i != 0 {
 			time.Sleep(intervalDuration)
-			releaseTime = releaseTime.Add(intervalDuration)
 		}
 		r.c.PrintLine("Deploying", time.Now().Format("15:04:05"), branch)
 

--- a/time/time.go
+++ b/time/time.go
@@ -1,0 +1,13 @@
+package time
+
+import "time"
+
+type Time struct{}
+
+func (w Time) Sleep(duration time.Duration) {
+	time.Sleep(duration)
+}
+
+func (w Time) Now() time.Time {
+	return time.Now()
+}


### PR DESCRIPTION
There was a little off-by-one error in the deployment flow, which didn't matter before as there was only one value. As there were not good  tests for this, it went by unnoticed.

By sleeping after the deployment, instead of before, this is solved. 
By making an interface for the time interactions, this can now be mocked and tested.